### PR TITLE
Let user specify SWIG location in configure argument

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,8 +4,6 @@ import atexit, os, sys
 sys.path.insert(0,'./framework')
 import bldutil, configure, setenv, rsf.doc
 
-env = Environment()
-
 if os.path.isfile('config.py'):
     import config
     root = config.RSFROOT
@@ -31,7 +29,8 @@ etcdir = os.path.join(shrdir, 'madagascar', 'etc')
 
 opts = configure.options('config.py')
 opts.Add('RSFROOT','RSF installation root',root)
-opts.Update(env)
+
+env = Environment(variables=opts)
 
 if not os.path.isfile('config.py'):
     conf = Configure(env,custom_tests={'CheckAll':configure.check_all})

--- a/framework/configure.py
+++ b/framework/configure.py
@@ -2189,7 +2189,7 @@ def swig(context):
         'that cannot be built with -static-intel',
         'yellow_on_red')
     context.Message("checking for SWIG ... ")
-    if 'swig' in Environment().get('TOOLS'):
+    if 'swig' in context.env.get('TOOLS'):
         swigx = WhereIs('swig')
         context.Result(swigx)
         context.env['SWIG'] = swigx


### PR DESCRIPTION
While compiling Madagascar as a [Conda](https://conda.io) package, I noticed that python API was not compiled because Madagascar's `configure` script could not find `swig` executable. However, `swig` was installed but into a conda environment (that is, not in one of the standard paths such as `/usr/bin/` or `/usr/local/bin`). Moreover, `configure` script accepts environment argument `SWIG=<location-of-swig>` but it does not help to determine actual swig location.

It turned out that at the moment when configure script checks for swig, the argument SWIG is not taken into account, hence, the script cannot find `swig`.

This pull request allows to build Madagascar by specifying swig location as a command-line argument of the `configure` script.
Actually, the following command is enough to pick up Conda-provided swig and correctly build python API (notice that argument `SWIG=swig` without full path `swig`):

    $ ./configure --prefix=/opt/apps/madagascar/rsfroot API=c++,python SWIG=swig



