### PR TITLE
Fix a couple of bugs in the _File class of Python API

### DIFF
--- a/api/python/m8r.py
+++ b/api/python/m8r.py
@@ -525,7 +525,7 @@ class _File(File):
                 quit()
         if self.type=='float':
             self.datatype=np.float32
-        elif self.type==complex:
+        elif self.type=='complex':
             self.datatype=np.complex64
         elif self.type=='int':
             self.datatype=np.int32

--- a/api/python/m8r.py
+++ b/api/python/m8r.py
@@ -512,7 +512,7 @@ class _File(File):
                 else:
                     sys.stderr.write('error reading from input file.\n')
                     sys.stderr.write('data_format=%s\n'%data_format)
-                    sys.stderr.write('filename=%s.\n',self.filename)
+                    sys.stderr.write('filename=%s.\n'%self.filename)
                     sys.stderr.write('data_format must be native_float, '+
                                      'native_complex or native_int\n')
                     sys.stderr.write('error - exiting program\n')
@@ -520,7 +520,7 @@ class _File(File):
             except:
                 sys.stderr.write('error reading from input file.\n')
                 sys.stderr.write('data_format is not defined\n')
-                sys.stderr.write('filename=%s.\n',self.filename)
+                sys.stderr.write('filename=%s.\n'%self.filename)
                 sys.stderr.write('error - exiting program\n')
                 quit()
         if self.type=='float':
@@ -532,7 +532,7 @@ class _File(File):
         else:
             sys.stderr.write('error reading from input file.\n')
             sys.stderr.write('self.type=%s\n'%self.type)
-            sys.stderr.write('filename=%s.\n',self.filename)
+            sys.stderr.write('filename=%s.\n'%self.filename)
             sys.stderr.write('self.type must be native_float, '+
                              'native_complex or native_int\n')
             sys.stderr.write('error - exiting program\n')


### PR DESCRIPTION
While reading RSF files with `type=complex` using Python API, I ran into a couple of bugs (which are actually interrelated, because one was causing another one) in the class `_File`:

1. Field 'type' of _File class incorrectly was compared to Python intrinsic
type `complex` instead of correct comparison with a string 'complex'.
Hence, when the input RSF file contains complex data, the datatype could
not be determined.

1. Function `sys.stderr.write` takes only one argument, while two arguments
were given erroneously.

This PR fixes both of these bugs.