### PR TITLE
New feature: Issues templates for bug report, documentation request and feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: Dirack
+
+---
+
+:bug:  Bug report
+
+**Description of the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+about: Documentation of readme, wikis, etc
+title: "[DOC]"
+labels: documentation
+assignees: Dirack
+
+---
+
+:octocat: **Documentation request**
+
+**Describe your documentation request clearly bellow**
+
+**Program version**
+
+**What kind of documentation you are requesting?**
+
+- [ ] README files.
+- [ ] Usage example.
+- [ ] Jupyter notebooks.
+- [ ] Other (_describe it here_)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEA]"
+labels: enhancement
+assignees: Dirack
+
+---
+
+:tada: **Feature request**
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

I've done issue templates for bug report, documentation request and feature request as answer to [this comment](https://github.com/ahay/src/issues/183#issuecomment-592082157) in issue #183. 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Context and images (if needed)**

Those are templates for issues that a user can follow and edit. They are stored in the .github/ISSUE_TEMPLATE directory

>Please contact me if you have any doubt or request.

>thanks,

>Rodolfo Dirack