### PR TITLE
m8r: fix issue #205

### DIFF
--- a/api/python/m8r.py
+++ b/api/python/m8r.py
@@ -788,7 +788,7 @@ class Input(_File):
                 lhs = tokenlist[0]
                 rhs = tokenlist[1]
                 quotmark = None
-                if rhs is list and rhs[0] in (squot, dquot):
+                if len(rhs) != 0 and rhs[0] in (squot, dquot):
                     if rhs[0] == squot:
                         quotmark = squot
                     else:


### PR DESCRIPTION
Small change to m8r to address issue #205 It also allows to read the rsf file (amoco velocity model) from #176 failing example. It seems there is a lack of an extensive suite of tests that may prevent that a change leads to other erros.