### PR TITLE
Add homebrew support

### DIFF
--- a/framework/configure.py
+++ b/framework/configure.py
@@ -302,7 +302,7 @@ def cc(context):
                                                   '/usr/local/include')
             if os.path.isdir('/usr/local/lib'):
                 context.env['LIBPATH'] = path_get(context, 'LIBPATH', 
-                								  '/usr/local/lib')
+                                                  '/usr/local/lib')
     # Solaris
     elif plat['OS'] == 'sunos':
         context.env['CFLAGS'] = context.env.get('CFLAGS','').replace(

--- a/framework/configure.py
+++ b/framework/configure.py
@@ -296,6 +296,13 @@ def cc(context):
             if os.path.isdir('/sw/lib'):
                 context.env['LIBPATH'] = path_get(context,'LIBPATH',
                                                   '/sw/lib')
+        if os.path.isdir('/usr/local/Homebrew'):  # paths for Homebrew
+            if os.path.isdir('/usr/local/include'):
+                context.env['CPPPATH'] = path_get(context, 'CPPPATH',
+                                                  '/usr/local/include')
+            if os.path.isdir('/usr/local/lib'):
+                context.env['LIBPATH'] = path_get(context, 'LIBPATH', 
+                								  '/usr/local/lib')
     # Solaris
     elif plat['OS'] == 'sunos':
         context.env['CFLAGS'] = context.env.get('CFLAGS','').replace(


### PR DESCRIPTION
Supporting MacOS package manager *Homebrew*.

Homebrew install itself at "/usr/local/Homebrew",  
the packages are installed at "/usr/local/Cellar", 
and the corresponding headers and libraries are linked at "/usr/local/include" and "/usr/local/lib", respectively.


