### PR TITLE
New Madagascar recipe: pefInterpolation.py

### DIFF
--- a/book/Recipes/pefInterpolation.py
+++ b/book/Recipes/pefInterpolation.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# pefInterpolation.py  (Madagascar Recipe)
+#
+# Purpose: Recipe to Predictive Adaptative Error Filters (PEF) interpolation
+# to double CMP number of samples in a section or data cube.
+#
+# Site: https://dirack.github.io
+# 
+# Version 1.0
+#
+# Programer: 
+#		-Saulo S Martins (ssmsaulo) 08/12/2016 - Article reference (2015)
+#		 	http://dx.doi.org/10.1190/segam2015-5924518.1
+#		 Email: ssmsaulo@gmail.com
+#
+#		-Hugo Souza (hugo-ss) 22/06/2019 - Original SConstruct code
+#		 Email: hugogeof@gmail.com
+#
+#		-Rodolfo A. C. Neves (Dirack) 27/05/2020 - This recipe
+#		 Email: rodolfo_profissional@hotmail.com
+#
+# License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+# Selfdoc string
+'''
+Madagascar recipe to PEF interpolation
+
+Interpolate and increase CMP sampling using Predictive Adaptative Error Filters (PEF) interpolation.
+'''
+
+if __name__ == "__main__":
+	print(__doc__)
+	exit()
+
+__author__="Rodolfo Dirack <rodolfo_profissional@hotmail.com>"
+__version__="1.0"
+
+# Madagascar package
+from rsf.proj import *
+
+def pefInterpolation(
+    dataCube,
+    interpolated,
+    nm,
+    dm,
+    nt,
+    dt,
+    nhi,
+    a1,
+    a2,
+    rect1,
+    rect2
+    ):
+    '''
+
+    PEF interpolation to double CMP sampling of the data cube
+
+    :param dataCube: RSF filename, Seismic data cube to interpolate
+    :param interpolated: RSF filename, Interpolated seismic data cube
+    :param nm: integer, number of CMPs in the seismic data cube
+    :param dm: float, CMP sampling
+    :param nt: integer, number of time samples
+    :param dt: float, time sampling
+    :param nhi: integer, number of constant offsets gathers to interpolate
+    :param a1: integer, Number of PEF coeficients in time axis
+    :param a2: integer, Number of PEF coeficients in space axis
+    :param rect1: integer, Smooth radius in time
+    :param rect2: integer, Smooth radius in space
+    '''
+
+    # Number of offset gathers should be positive and non zero
+    assert nhi>=1, 'Number of offset gathers (nhi) should be >= 1, you used (nhi=%i)' % nhi
+
+    # Divide CMP sampling
+    dm = dm/2
+
+    # Define mask file names using input filename
+    mask1 = dataCube+'-mask1'
+    mask = dataCube+'-mask'
+    aa = dataCube+'-aa'
+    bb = dataCube+'-bb'
+    a = dataCube+'-a'
+    b = dataCube+'-b'
+    zeroTraceGather = dataCube+'-zeroedGather'
+    mask0 = dataCube+'-mask0'
+
+
+    # Build a mask to interleave zero traces with original data traces
+    Flow(aa,None,'spike n1=%i d1=%g o1=0' %(nm,dm))
+    Flow(bb,None,'spike n1=%i d1=%g o1=0 mag=0' % (nm,dm))
+    Flow(mask1,[bb, aa],
+            '''
+            interleave axis=1 ${SOURCES[1]} |
+            dd type=int
+            ''')
+
+    Flow(a,None,'spike n1=%i d1=%g o1=0' % (nm,dm))
+    Flow(b,None,'spike n1=%i d1=%g o1=0 mag=0' % (nm,dm))
+    Flow(mask,[a, b],
+            '''
+            interleave axis=1 ${SOURCES[1]} |
+            dd type=int
+            ''')
+    Flow(zeroTraceGather,b,
+            '''
+            spray axis=2 n=%i d=%g |
+            transp |
+            put label2=Offset unit2=Km label1=Time unit1=s
+            ''' %(nt,dm))
+
+    # Data Mask with double of traces in CMP (half of CMP sampling)
+    # Keep the same Time and Offset original data sampling
+    Flow(mask0,mask,
+         '''
+         spray axis=1 n=%i d=%g
+         ''' %(nt,dt))
+
+    totalPefIterations = 100
+    totalInterpolationIterations = 50
+
+    offsetGathers = []
+    for offsetGatherIndex in range(nhi):
+
+            offsetGather = dataCube+"-offsetGather-%i" % offsetGatherIndex
+            resampledOffsetGather = dataCube+"-resampledGather-%i" % offsetGatherIndex
+            interpolatedOffsetGather = dataCube+"-interpolatedGather-%i" % offsetGatherIndex
+            pefCoeficients = dataCube+"-pefCoeficients-%i" % offsetGatherIndex
+
+            Flow(offsetGather,dataCube,
+            '''
+            window n2=1 f2=%i
+            ''' % (offsetGatherIndex))
+            
+            Flow(resampledOffsetGather,[offsetGather,zeroTraceGather],
+            '''
+            interleave axis=2 ${SOURCES[1]}
+            ''')
+
+            # Calculate adaptive PEF coeficients
+            Flow(pefCoeficients,[resampledOffsetGather,mask0],
+                    '''
+                    apef jump=2 a=%i,%i rect1=%i rect2=%i niter=%g verb=y
+                    maskin=${SOURCES[1]}
+                    ''' % (a1,a2,rect1,rect2,totalPefIterations))
+
+            # Interpolation
+            Flow(interpolatedOffsetGather, 	[resampledOffsetGather,pefCoeficients,mask0,mask1],
+                    '''
+                    miss4 exact=y filt=${SOURCES[1]} mask=${SOURCES[2]} niter=%g verb=y |
+                    put d2=%g
+                    ''' % (totalInterpolationIterations,dm))
+
+            offsetGathers.append(interpolatedOffsetGather)
+
+    # Concatenate interpolated sections
+    Flow(interpolated,offsetGathers,
+            '''
+            rcat axis=3 ${SOURCES[1:%d]} |
+            transp plane=23
+            ''' % nhi)
+
+

--- a/book/dirack/examples/pefInterpolation/README.md
+++ b/book/dirack/examples/pefInterpolation/README.md
@@ -1,0 +1,67 @@
+#### Usage example of pefInterpolation.py recipe to double CMP data sampling
+
+This Sconstruct shows how to use functions defined in pefInterpolation.py recipe.
+
+As initial step, to build the input of pefInterpolation function (stacked section), it uses 
+[kimodel.py](https://github.com/ahay/src/blob/master/book/Recipes/kimodel.py) and
+[velocityAnalysis.py](https://github.com/ahay/src/blob/master/book/Recipes/velocityAnalysis.py) recipes to 
+generates a multi layer model with 3 layers and 2 interfaces, apply Kirchhoff-Newton modeling
+to generate a seismic data cube (Time x Offset x CMP data) and to do
+velocity analysis with automatic velocity picking to generate the stacked section.
+
+So, it generates another stacked section with doubled number of CMP samples through Predictive Adaptative Error Filters (PEF) interpolation
+in two steps (it is done inside the function): First, it interleaves the original stacked section with zeroed traces and it calculates the
+PEF coeficients using the program _sfapef_. Second, it interpolates zeroed traces using original traces in the neighborhood as a priori information.
+Interpolation is done with the program _sfmiss4_.
+
+```py
+# Transpose to (time x offset x CMP)
+Flow('transposedSection','stackedSection','transp plane=23')
+
+# PEF coeficients
+a1=10
+a2=4
+
+# PEF smooth radius
+rect1=10
+rect2=5
+
+# PEF interpolation of zero offset section
+pef('transposedSection',
+	'section',
+	nm=201,
+	dm=0.025,
+	nt=1001,
+	dt=0.004,
+	nhi=1,
+	a1=a1,
+	a2=a2,
+	rect1=rect1,
+	rect2=rect2
+)
+```
+
+The same process is done with the first 3 offset gathers in the seismic data cube, stored in the file 'multiLayerDataCube.rsf' (data cube is the seismic data
+organized in time x Offset x CMP coordinates). The number of offset gathers to interpolate extracted from the data cube is controled by _nhi_ parameter
+passed to the function pefInterpolation (in this example called as pef function).
+
+```py
+# PEF interpolation of some offset gathers
+# of the data cube (time x offset x CMP)
+pef('multiLayerDataCube',
+	'interpolatedDataCube',
+	nm=201,
+	dm=0.025,
+	nt=1001,
+	dt=0.004,
+	nhi=3,
+	a1=a1,
+	a2=a2,
+	rect1=rect1,
+	rect2=rect2
+)
+```
+
+The parameters _a1_ and _a2_ are the number of PEF coeficients to calculate for each sample, in time and space, respectively.
+The _rect1_ and _rect2_ parameters are the smoothing radius in time and space, respectively. Those parameters were chosen through
+trial and error for this problem (the parameters that build the better interpolated section were chosen).

--- a/book/dirack/examples/pefInterpolation/SConstruct
+++ b/book/dirack/examples/pefInterpolation/SConstruct
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# SConstruct (Madagascar Script)
+# 
+# Purpose: Predictive Adaptative Error Filter (PEF) interpolation
+# of a zero offset section and a data cube to increase CMP data sampling.
+# 
+# Site: https://dirack.github.io
+# 
+# Version 1.0
+# 
+# Programer: Rodolfo A C Neves (Dirack) 02/09/2020
+# 
+# Email: rodolfo_profissional@hotmail.com
+# 
+# License: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+from rsf.proj import *
+
+# Import recipes
+from rsf.recipes.kimodel import multiLayerModel as mlmod
+from rsf.recipes.kimodel import kirchhoffNewtonModeling as kinewmod
+from rsf.recipes.velocityAnalysis import velocityAnalysis as nmoStack
+from rsf.recipes.pefInterpolation import pefInterpolation as pef
+
+xmax = 6.0
+zmax = 2.0
+
+layers = ((0.30,0.50,0.20,0.30),
+	  (1.65,1.85,1.55,1.65))
+
+velocities = (1.508,
+	      1.690,
+	      2.0)
+
+# Generate multi layer model and data cube
+mlmod(interfaces='interfaces',
+	dipsfile='interfacesDip',
+	modelfile='mod1',
+	xmax=xmax,
+	zmax=zmax,
+	layers=layers,
+	velocities=velocities)
+
+# Kirchhoff Newton modeling
+kinewmod(reflectors='interfaces',
+	reflectorsDip='interfacesDip',
+	filename='multiLayerDataCube',
+	velocities=velocities,
+	nt=1001,
+	dt=0.004,
+	ns=201,
+	ds=0.025,
+	nh=161,
+	dh=0.025)
+
+# velocity analysis, NMO correction and stack
+nmoStack(dataCube='multiLayerDataCube',
+	pick='vnmo',
+	stack='stackedSection',
+	vrms='vrms',
+	v0=1.5,
+	dv=0.01,
+	nv=100,
+	vel0=1.5,
+	rect1=15,
+	rect2=40,
+	rect3=3,
+	dt=0.004)
+
+# Transpose to (time x offset x CMP)
+Flow('transposedSection','stackedSection','transp plane=23')
+
+# PEF coeficients
+a1=10
+a2=4
+
+# PEF smooth radius
+rect1=10
+rect2=5
+
+# PEF interpolation of zero offset section
+pef('transposedSection',
+	'section',
+	nm=201,
+	dm=0.025,
+	nt=1001,
+	dt=0.004,
+	nhi=1,
+	a1=a1,
+	a2=a2,
+	rect1=rect1,
+	rect2=rect2
+)
+
+# Section with increased CMP number of samples
+Flow('interpolatedStackedSection','section','transp plane=23')
+
+# PEF interpolation of some offset gathers
+# of the data cube (time x offset x CMP)
+pef('multiLayerDataCube',
+	'interpolatedDataCube',
+	nm=201,
+	dm=0.025,
+	nt=1001,
+	dt=0.004,
+	nhi=3,
+	a1=a1,
+	a2=a2,
+	rect1=rect1,
+	rect2=rect2
+)


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Description**

This new Madagascar recipe doubles CMP data sampling using Predictive Adaptative Error Filters (PEF) interpolation.

* This recipe works in two steps: First, it interleaves zeroed traces with original traces in an offset gather and it uses the program _sfapef_ to calculate the PEF coefficients. Second, it interpolates the interleaved zeroed traces using the program _sfmiss4_. Original traces in the neighborhood of the zeroed traces are used as a priori information.

* It can be done for one offset gather (or stacked section) or a set of offset gathers extracted from a data cube (Time x Offset x CMP). The number of offset gathers to apply the interpolation is controlled by _nhi_ parameter.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Add images bellow and additional context if needed**

This Pull Request has a usage example of the pefInterpolation.py recipe applied in a stacked section and in a data cube.

* To generate another stacked section with a doubled number of CMP samples through Predictive Adaptative Error Filters (PEF) interpolation:

```py
# Transpose to (time x offset x CMP)
Flow('transposedSection','stackedSection','transp plane=23')

# PEF coefficients
a1=10
a2=4

# PEF smooth radius
rect1=10
rect2=5

# PEF interpolation of zero offset section
pef('transposedSection',
	'section',
	nm=201,
	dm=0.025,
	nt=1001,
	dt=0.004,
	nhi=1,
	a1=a1,
	a2=a2,
	rect1=rect1,
	rect2=rect2
)
```

The first parameter is the stacked section (it is transposed because the function works with data in Time x Offset x CMP coordinates), the second is the interpolated section, nm is the number CMPs, dm is the original CMP data sampling, nt is the number of time samples, dt is the time sampling, nhi is the number of offset gathers to interpolate.

The parameters _a1_ and _a2_ are the number of PEF coefficients to calculate for each sample, in time and space, respectively. The _rect1_ and _rect2_ parameters are the smoothing radius in time and space, respectively. Those parameters were chosen through trial and error for this problem (the parameters that build the better-interpolated section were chosen).

The original and expected geometry of the sections are, respectively:

```
~$sfin transposedSection.rsf 
transposedSection.rsf:
    in="/var/tmp/home/dirack/pef/transposedSection.rsf@"
    esize=4 type=float form=native 
    n1=1001        d1=0.004       o1=0          label1="Time" unit1="s" 
    n2=1           d2=0.025       o2=0          label2="CMP" unit2="Km" 
    n3=201         d3=0.025       o3=0          label3="CMP" unit3="Km" 
	201201 elements 804804 bytes

~$ sfin section.rsf 
section.rsf:
    in="/var/tmp/home/dirack/pef/section.rsf@"
    esize=4 type=float form=native 
    n1=1001        d1=0.004       o1=0          label1="Time" unit1="s" 
    n2=1           d2=0.025       o2=0          label2="CMP" unit2="Km" 
    n3=402         d3=0.0125      o3=0          label3="CMP" unit3="Km" 
	402402 elements 1609608 bytes
```

It doubled nm and divided dm by two.

* To apply the interpolation process in the first 3 offset gathers in the seismic data cube stored in the file 'multiLayerDataCube.rsf' (nhi=3):

```py
# PEF interpolation of some offset gathers
# of the data cube (time x offset x CMP)
pef('multiLayerDataCube',
	'interpolatedDataCube',
	nm=201,
	dm=0.025,
	nt=1001,
	dt=0.004,
	nhi=3,
	a1=a1,
	a2=a2,
	rect1=rect1,
	rect2=rect2
)
```


```
