### PR TITLE
fix_fedora_libraries

### DIFF
--- a/framework/configure.py
+++ b/framework/configure.py
@@ -353,7 +353,7 @@ def ar(context):
         context.Result(context_failure)
         need_pkg('ar')
 
-pkg['libs'] = {'fedora':'glibc-headers',
+pkg['libs'] = {'fedora':'libtirpc-devel (Setup...Libs)',
                'cygwin':'libtirpc-devel (Setup...Libs)',
                'centos':'libtirpc-devel (Setup...Libs)'}
 
@@ -371,7 +371,8 @@ def libs(context):
         LIBS.append('nsl')
         LIBS.append('socket')
     elif plat['OS'] == 'cygwin' or \
-         (plat['distro'] == 'centos' and plat['version'] == 8):
+         (plat['distro'] == 'centos' and plat['version'] == 8) or \
+	 plat['distro'] == 'fedora':
         context.env['CPPPATH'] = path_get(context,'CPPPATH',
                                           '/usr/include/tirpc')
         LIBS.append('tirpc')


### PR DESCRIPTION
Issue report and fix.

OS platform info:
```shell
➜ cat /etc/os-release   
NAME=Fedora
VERSION="31 (Workstation Edition)"
ID=fedora
VERSION_ID=31
VERSION_CODENAME=""
PLATFORM_ID="platform:f31"
PRETTY_NAME="Fedora 31 (Workstation Edition)"
```

Before installation, environment configuration may have some problem in Fedora:
```shell
➜ ./configure API=python3 --prefix=~/madagascar
checking for Python ... /home/zzs/miniconda3/bin/python
checking Python version ... 3.7.7
checking for RSFROOT ... ~/madagascar
checking for SCons ... /home/zzs/miniconda3/bin/scons
checking SCons version ... v3.1.2.bee7caf9defd6e108fc2998a2520ddb36a967691
Running RSFROOT=~/madagascar /home/zzs/miniconda3/bin/scons  config ...
------------------------
scons: Reading SConscript files ...
checking platform ... (cached) linux [fedora]
checking for C compiler ... (cached) gcc
checking if gcc works ... yes
checking if gcc accepts '-x c -std=gnu99 -Wall -pedantic' ... yes
checking for ar ... (cached) ar
checking for libraries ... no

  Needed package: glibc-headers

  Fatal missing dependency
------------------------
Done with configuration.
```
The detail shows in config.log:
```shell
scons: Configure: checking for libraries ... 
.sconf_temp/conftest_2.c <-
  |
  |    #include <rpc/types.h>
  |    #include <rpc/xdr.h>
  |    int main(int argc,char* argv[]) {
  |    return 0;
  |    }
  |
gcc -o .sconf_temp/conftest_2.o -c -O2 -x c -std=gnu99 -Wall -pedantic .sconf_temp/conftest_2.c
.sconf_temp/conftest_2.c:2:14: fatal error: rpc/types.h: No such file or directory
    2 |     #include <rpc/types.h>
      |              ^~~~~~~~~~~~~
compilation terminated.
scons: Configure: no
```

The rpc/types.h is the file in the libtirpc-devel package that was taken out of glibc alone after the Fedora 7 release.

Problem fix:
- fix error message as "fedora':'libtirpc-devel (Setup...Libs)".
- add CPPPATH "/usr/include/tirpc" while platform is "fedora".

Then I can go through the configuration:
```shell
scons: Reading SConscript files ...
checking platform ... (cached) linux [fedora]
checking for C compiler ... (cached) gcc
checking if gcc works ... yes
checking if gcc accepts '-x c -std=gnu99 -Wall -pedantic' ... yes
checking for ar ... (cached) ar
checking for libraries ... ['m', 'tirpc']
checking complex support ... yes
checking for X11 headers ... /usr/include
checking for X11 libraries ... /usr/lib
checking for OpenGL ... yes
checking for sfpen ... (cached) xtpen
checking for ppm ... yes
checking for tiff ... yes
checking for GD (PNG) ... yes
checking for GD (GIF) ... yes
checking for plplot ... yes
checking for ffmpeg ... yes
checking for cairo (PNG) ... yes
checking for cairo (SVG) ... yes
checking for cairo (PDF) ... yes
checking for jpeg ... yes
checking for BLAS ... yes
checking for LAPACK ... yes
checking for SWIG ... (cached) /usr/bin/swig
checking for numpy ... (cached) yes
checking API options ... (cached) []
checking for C++ compiler ... (cached) g++
checking if g++ works ... yes
checking if g++ accepts '-std=c++11 -U__STRICT_ANSI__ -Wall -pedantic' ... yes
checking for MPICC ... (cached) /usr/lib64/openmpi/bin/mpicc
checking if /usr/lib64/openmpi/bin/mpicc works ... yes
checking for MPICXX ... (cached) /usr/lib64/openmpi/bin/mpicxx
checking if /usr/lib64/openmpi/bin/mpicxx works ... yes
checking for MPIRUN ... (cached) /usr/lib64/openmpi/bin/mpirun
checking for Posix threads ... yes
checking for OpenMP ... yes
checking for CUDA ... (cached) no
checking for FFTW ... yes
checking if FFTW supports threads ... yes
checking for SuiteSparse ... yes
checking for pfft ... no
scons: done reading SConscript files.
scons: Building targets ...
shell_script(["env.sh"], [])
shell_script(["env.csh"], [])
scons: done building targets.
------------------------
Done with configuration.
```