### PR TITLE
Chapel API

### DIFF
--- a/api/chapel/SConstruct
+++ b/api/chapel/SConstruct
@@ -1,0 +1,19 @@
+import sys, os
+sys.path.append('../../framework')
+import bldutil
+
+modules = ['m8r']
+
+try: # distribution version
+    Import('env root libdir incdir')
+    env = env.Clone()
+except: # local version
+    env = bldutil.Debug()
+    root = None
+
+for module in modules:
+    env.Install('../../lib',module+'.chpl')
+
+if root:
+    for module in modules:
+        env.Install(libdir,module+'.chpl')

--- a/api/chapel/m8r.chpl
+++ b/api/chapel/m8r.chpl
@@ -1,0 +1,374 @@
+/* RSF-Chapel interface */
+/*
+  Copyright (C) 2021 Jorge Monsegny
+ 
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+ 
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+module m8r {
+
+    require "rsf.h";
+
+    use SysBasic;
+    use SysCTypes;
+
+    //Extern declaration of C Madagascar procedures
+    //and datatypes w=wrapper nw=no wrapper
+
+    //Functions for Madagascar initialization and closure
+    extern proc sf_init(argc: c_int, argv: [] c_ptr(c_char)): void; //w
+    extern proc sf_close() : void; //nw
+
+    //Functions for opening and closing files
+    extern type sf_file;
+    extern proc sf_input(tag : c_string) : sf_file; //w
+    extern proc sf_output(tag : c_string) : sf_file; //w
+    extern proc sf_fileclose(file : sf_file) : void; //nw
+
+    //Functions to get/set file type
+    extern type sf_datatype = c_int;
+    extern const SF_UCHAR :sf_datatype;
+    extern const SF_CHAR :sf_datatype;
+    extern const SF_INT :sf_datatype;
+    extern const SF_FLOAT :sf_datatype;
+    extern const SF_COMPLEX :sf_datatype;
+    extern const SF_SHORT :sf_datatype;
+    extern const SF_DOUBLE :sf_datatype;
+    extern const SF_LONG :sf_datatype;
+    extern proc sf_gettype(file : sf_file) : sf_datatype; //nw
+    extern proc sf_settype(file : sf_file, type_arg : sf_datatype) : void; //nw
+
+    //Functions to get/set file form
+    extern type sf_dataform = c_int;
+    extern const SF_ASCII :sf_dataform;
+    extern const SF_XDR :sf_dataform;
+    extern const SF_NATIVE :sf_dataform;
+    extern proc sf_getform(file : sf_file) : sf_dataform; //nw
+    extern proc sf_setform(file : sf_file, form : sf_dataform) : void; //nw
+    extern proc sf_setformat(file : sf_file, format : c_string) : void; //nw
+
+    //Terminal functions
+    extern proc sf_warning(format : c_string) : void; //w
+    extern proc sf_error(format : c_string) : void; //w
+
+    //Functions to get keys from files 
+    extern proc sf_histint(file : sf_file, 
+                           key : c_string, 
+                           ref par : int(32)) : bool; //nw
+    extern proc sf_histints(file : sf_file,
+                            key : c_string,
+                            par : c_ptr(c_int),
+                            n : int(32)) : bool; //w
+    extern proc sf_histlargeint(file : sf_file,
+                                key : c_string,
+                                ref par : int(64)) : bool; //nw
+    extern proc sf_histfloat(file : sf_file, 
+                             key : c_string, 
+                             ref par : real(32)) : bool; //nw
+    extern proc sf_histfloats(file : sf_file,
+                              key : c_string,
+                              par : c_ptr(c_float),
+                              n : int(32)) : bool; //w
+    extern proc sf_histbool(file : sf_file, 
+                            key : c_string, 
+                            ref par : bool) : bool; //nw
+    extern proc sf_histbools(file : sf_file,
+                             key : c_string,
+                             par : c_ptr(bool),
+                             n : int(32)) : bool; //w
+    extern proc sf_histdouble(file : sf_file, 
+                              key : c_string, 
+                              ref par : real(64)) : bool; //nw
+    extern proc sf_histstring(file : sf_file,
+                              key : c_string) : c_string; //nw
+
+    //Functions to put keys in files
+    extern proc sf_putint(file : sf_file, 
+                          key : c_string, 
+                          par : c_int) : void; //nw
+    extern proc sf_putlargeint(file : sf_file, 
+                               key : c_string, 
+                               par : c_long) : void; //nw
+    extern proc sf_putints(file : sf_file, key : c_string, 
+                           par : [] c_int, n : c_int) : void; //w
+    extern proc sf_putfloat(file : sf_file, 
+                            key : c_string, 
+                            par : c_float) : void; //nw
+    extern proc sf_putstring(file : sf_file, 
+                             key : c_string, 
+                             par : c_string) : void; //nw
+    extern proc sf_putline(file : sf_file, line : c_string) : void; //nw
+
+    //Size functions
+    extern const SF_MAX_DIM : int;
+    extern proc sf_leftsize(file : sf_file, dim : int(32)) : int(32); //nw
+    extern proc sf_filedims(file : sf_file, n : c_ptr(c_int)) : int(32); //w
+    extern proc sf_largefiledims(file : sf_file, 
+                                 n : c_ptr(c_long)) : int(32); //w 
+    extern proc sf_filesize(file : sf_file) : c_int; //nw
+    extern proc sf_esize(file : sf_file) : c_int; //nw
+
+    //Functions that read command line parameters
+    extern proc sf_getint(key : c_string, ref par : int(32)) : bool; //nw
+    extern proc sf_getlargeint(key : c_string, ref par : int(64)) : bool; //nw
+    extern proc sf_getints(key : c_string, par : c_ptr(c_int), n : int(32)) : bool; //w
+    extern proc sf_getfloat(key : c_string, ref par : real(32)) : bool; //nw
+    extern proc sf_getdouble(key : c_string, ref par : real(64)) : bool; //nw
+    extern proc sf_getfloats(key : c_string, par : c_ptr(c_float), n : int(32)) : bool; //w
+    extern proc sf_getstring(key : c_string) : c_string; //nw
+    extern proc sf_getstrings(key : c_string, par : [] c_ptr(c_char), n : int(32)) : bool; //w looks like the strings are colon separated: par=str1:str2:...
+    extern proc sf_getbool(key : c_string, ref par : bool) : bool; //nw
+    extern proc sf_getbools(key : c_string, par : c_ptr(bool), n : int(32)) : bool; //w
+
+    //Complex external type
+    extern type sf_complex;
+
+    //Read data routines.  
+    extern proc sf_complexread(arr : c_ptr(sf_complex), 
+                               size : c_int, 
+                               file : sf_file) : void; //w  
+    extern proc sf_floatread(arr : c_ptr(c_float), 
+                             size : c_int, 
+                             file : sf_file) : void; //w
+    extern proc sf_intread(arr : c_ptr(c_int), 
+                           size : c_int, 
+                           file : sf_file) : void; //w
+    extern proc sf_shortread(arr : c_ptr(c_short),
+                             size : c_int,
+                             file : sf_file) : void; //w
+    extern proc sf_charread(arr : c_ptr(c_char),
+                            size : c_int,
+                            file : sf_file) : void; //w
+    extern proc sf_uncharread(arr : c_ptr(c_uchar),
+                              size : c_int,
+                              file : sf_file) : void; //w
+
+    //Data writing routines
+    //sf_complexwrite is not implemented
+    extern proc sf_complexwrite(arr : c_ptr(sf_complex),
+                                size : c_int,
+                                file : sf_file) : void; //w
+    extern proc sf_floatwrite(arr : c_ptr(c_float), 
+                              size : c_int, 
+                              file : sf_file) : void; //w
+    extern proc sf_intwrite(arr : c_ptr(c_int), 
+                            size : c_int, 
+                            file : sf_file) : void; //w
+    extern proc sf_shortwrite(arr : c_ptr(c_short),
+                              size : c_int,
+                              file : sf_file) : void; //w
+    extern proc sf_charwrite(arr : c_ptr(c_char),
+                             size : c_int,
+                             file : sf_file) : void; //w
+    extern proc sf_uncharwrite(arr : c_ptr(c_uchar),
+                               size : c_int,
+                               file : sf_file) : void; //w
+
+    //Some procedures wrappers
+
+    //Functions for Madagascar initialization and closure
+    proc sf_init(args: [] string) : void
+    {
+        var argv: [0..args.size-1] c_ptr(c_char);        
+        for i in (0..args.size-1) {
+            var tmp: c_string = args[i].localize().c_str();            
+            argv[i] = tmp:c_ptr(c_char);          
+        }
+        sf_init(args.size:c_int, argv);
+    }
+
+    //Functions for opening and closing files
+    proc sf_input(tag: string): sf_file
+    {
+        return sf_input(tag.c_str());
+    }
+
+    proc sf_output(tag: string): sf_file
+    {   
+        return sf_output(tag.c_str());
+    }
+
+    //Terminal functions
+    proc sf_warning(args...?n) : void
+    {   
+        var msg: string;
+        for param i in 0..n-1 {//param must be here because args is heterogenous
+            msg += args(i):string;
+        }
+        sf_warning(msg.c_str());
+    }
+
+    proc sf_error(args...?n) : void
+    {
+        var msg: string;
+        for param i in 0..n-1 {//param must be here because args is heterogenous
+            msg += args(i):string;
+        }
+        sf_error(msg.c_str());
+    }
+
+    //Size functions
+    proc sf_filedims(file : sf_file, n : [] int(32)) : int
+    {
+        var cn = c_ptrTo(n);
+        return sf_filedims(file, cn);        
+    }
+
+    proc sf_largefiledims(file : sf_file, n : [] int(64)) : int(32)
+    {
+        var cn = c_ptrTo(n);
+        return sf_largefiledims(file, cn);
+    }
+
+    //Functions to get keys from files
+    proc sf_histints(file : sf_file, key : string, 
+                     par : [] int(32), n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_histints(file, key.c_str(), cpar, n);
+    }
+
+    proc sf_histfloats(file : sf_file, key : string, 
+                       par : [] real(32), n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_histfloats(file, key.c_str(), cpar, n);
+    }
+
+    proc sf_histbools(file : sf_file, key : string, 
+                      par : [] bool, n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_histbools(file, key.c_str(), cpar, n);
+    }
+
+
+    //Functions that read command line parameters
+    proc sf_getints(key : string, par : [] int(32), n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_getints(key.c_str(), cpar, n);
+    }
+
+    proc sf_getfloats(key : string, par : [] real(32), n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_getfloats(key.c_str(), cpar, n);
+    }
+
+    proc sf_getstrings(key : string, par : [] string, n : int(32)) : bool
+    {
+        var cpar: [0..n-1] c_ptr(c_char);
+        var ret = sf_getstrings(key.c_str(), cpar, n);
+        for i in 0..n-1 {
+            par[i] = cpar[i]:c_string;
+        }
+        return ret;
+    }
+
+    proc sf_getbools(key : string, par : [] bool, n : int(32)) : bool
+    {
+        var cpar = c_ptrTo(par);
+        return sf_getbools(key.c_str(), cpar, n);
+    }
+
+    //Data reading functions
+    proc sf_complexread(arr : [] complex(64), size : int, 
+                        file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_complexread(carr:c_ptr(sf_complex), csize, file);
+    }
+
+    proc sf_floatread(arr : [] real(32), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_floatread(carr, csize, file);
+    }
+
+    proc sf_intread(arr : [] int(32), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_intread(carr, csize, file);
+    }
+
+    proc sf_shortread(arr : [] int(16), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_shortread(carr, csize, file);
+    }
+
+    proc sf_charread(arr : [] int(8), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_charread(carr, csize, file);
+    }
+
+    proc sf_uncharread(arr : [] uint(8), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_ucharread(carr, csize, file);
+    }
+
+    //Data writing functions
+    proc sf_complexwrite(arr : [] complex(64), size : int, 
+                         file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_complexwrite(carr:c_ptr(sf_complex), csize, file);
+    }
+
+    proc sf_floatwrite(arr : [] real(32), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_floatwrite(carr, csize, file);
+    }
+  
+    proc sf_intwrite(arr : [] int(32), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_intwrite(carr, csize, file);
+    }
+
+    proc sf_shortwrite(arr : [] int(16), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_shortwrite(carr, csize, file);
+    }
+   
+    proc sf_charwrite(arr : [] int(8), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_charwrite(carr, csize, file);
+    }
+
+    proc sf_uncharwrite(arr : [] uint(8), size : int, file : sf_file) : void
+    {
+        var carr = c_ptrTo(arr);
+        var csize: c_int = size: int(32);
+        sf_uncharwrite(carr, csize, file);
+    }
+}

--- a/api/chapel/test/SConstruct
+++ b/api/chapel/test/SConstruct
@@ -1,0 +1,22 @@
+import rsf.proj
+
+proj = rsf.proj.Project()
+
+# Builder for chapel code with rsf interface
+chprsf = Builder(action = '$CHPL $CHPLFLAGS -I$INCDIR -L$LIBDIR -M$LIBDIR -l$LIBS $SOURCES $OPT -o $TARGET')
+proj.Append(BUILDERS = {'chprsf' : chprsf})
+
+# Build programs
+proj.chprsf('clip.exe', Split('clip.chpl'), CHPL=proj.get('CHPL_HOST_COMPILER'), INCDIR=proj.get('CPPPATH'), LIBDIR=proj.get('LIBPATH'), LIBS='rsf', OPT='')
+
+proj.chprsf('afdm.exe', Split('afdm.chpl'), CHPL=proj.get('CHPL_HOST_COMPILER'), INCDIR=proj.get('CPPPATH'), LIBDIR=proj.get('LIBPATH'), LIBS='rsf', OPT='')
+
+# Test programs
+proj.Flow('test.attr','clip.exe',
+          '''
+          spike n1=1000 n2=100 n3=10 nsp=1 k1=500 |
+          ./$SOURCE clip=0.5 | attr
+          ''',stdin=0)
+
+proj.End()
+

--- a/api/chapel/test/afdm.chpl
+++ b/api/chapel/test/afdm.chpl
@@ -1,0 +1,98 @@
+// Time-domain acoustic FD modeling
+
+// Chapel-Madagascar API
+use m8r;
+
+proc main(args: [] string)
+{
+    // Laplacian coefficients
+    const c0 = -30.0/12: real(32);
+    const c1 =  16.0/12: real(32);
+    const c2 = -1.0/12:  real(32);
+
+    sf_init(args); // init RSF
+    var verb: bool; // verbose flag
+    if( !sf_getbool("verb", verb) ) then verb = false;
+
+    // Setup I/O files
+    var Fw: sf_file = sf_input("in");
+    var Fv: sf_file = sf_input("vel");
+    var Fr: sf_file = sf_input("ref");
+    var Fo: sf_file = sf_output("out");
+
+    // Read/Write axes
+    var nt:  int(32); sf_histint  ( Fw, "n1", nt ); 
+    var dt: real(32); sf_histfloat( Fw, "d1", dt );
+    var nz:  int(32); sf_histint  ( Fv, "n1", nz );
+    var dz: real(32); sf_histfloat( Fv, "d1", dz );
+    var nx:  int(32); sf_histint  ( Fv, "n2", nx );
+    var dx: real(32); sf_histfloat( Fv, "d2", dx );
+
+    sf_putint  ( Fo, "n1", nz );
+    sf_putfloat( Fo, "d1", dz );
+    sf_putint  ( Fo, "n2", nx );
+    sf_putfloat( Fo, "d2", dx );
+    sf_putint  ( Fo, "n3", nt );
+    sf_putfloat( Fo, "d3", dt );
+
+    var dt2: real(32) = dt**2;
+    var idz: real(32) = 1.0/(dz**2);
+    var idx: real(32) = 1.0/(dx**2);
+
+    // Read wavelet, velocity and reflectivity
+    var ww: [0..nt-1]       real(32); sf_floatread( ww, nt, Fw );
+    var vv: [0..<nx,0..<nz] real(32); sf_floatread( vv, nz*nx, Fv );
+    var rr: [0..<nx,0..<nz] real(32); sf_floatread( rr, nz*nx, Fr );
+
+    // Allocate temporary arrays
+    var um: [0..<nz,0..<nx] real(32);
+    var uo: [0..<nz,0..<nx] real(32);
+    var up: [0..<nz,0..<nx] real(32);
+    var ud: [0..<nz,0..<nx] real(32);
+
+    // Main loop
+    for it in 0..nt-1 {
+
+        // 4th order laplacian
+        forall (ix,iz) in {2..nx-3,2..nz-3} {
+            ud[ix,iz] = c0* uo[ix,  iz  ]                 *(idx + idz) +
+                        c1*(uo[ix,  iz-1] + uo[ix,  iz+1])*idx +
+                        c2*(uo[ix,  iz-2] + uo[ix,  iz+2])*idx +
+                        c1*(uo[ix-1,iz  ] + uo[ix+1,iz  ])*idz +
+                        c2*(uo[ix-2,iz  ] + uo[ix+2,iz  ])*idz;  
+        }
+
+	// Inject wavelet
+        forall (ix,iz) in {0..<nx,0..<nz} {
+            ud[ix,iz] -= ww[it] * rr[ix,iz];
+        }
+
+        // Scale by velocity
+        forall (ix,iz) in {0..<nx,0..<nz} {
+            ud[ix,iz] *= vv[ix,iz]**2;
+        }
+
+        // Time step
+        forall (ix,iz) in {0..<nx,0..<nz} {
+            up[ix,iz] = 2.0*uo[ix,iz] -
+                            um[ix,iz] +
+                            ud[ix,iz] * dt2;                        
+        }
+
+	// Interchange wavefiels
+	um = uo;
+        uo = up;
+
+	// Write wavefield to output
+        sf_floatwrite( uo, nz*nx, Fo );
+    }
+
+    // Close files
+    sf_fileclose( Fw );
+    sf_fileclose( Fv );
+    sf_fileclose( Fr );
+    sf_fileclose( Fo );
+
+    // End Madagascar
+    sf_close();
+} 

--- a/api/chapel/test/clip.chpl
+++ b/api/chapel/test/clip.chpl
@@ -1,0 +1,57 @@
+// Chapel-Madagascar API
+use m8r;
+
+// Clipping value as config.
+// This would allow the cli syntax --clip=
+//config var clip: real(32) = 100.0;
+
+proc main(args: [] string)
+{
+    // Initialize Madagascar
+    sf_init(args);
+
+    // Get input and output files
+    var fin: sf_file = sf_input("in");
+    var fout: sf_file = sf_output("out");
+
+    // Input file must be float
+    if SF_FLOAT != sf_gettype(fin) then
+        sf_error("Need float input");
+    
+    // Number of samples
+    var n1: int(32);
+    if !sf_histint(fin,"n1",n1) then
+        sf_error("No n1= in input");    
+
+    // Number of traces
+    var n2 = sf_leftsize(fin,1);
+
+    // Get params
+    var clip: real(32);
+    if !sf_getfloat("clip", clip) then
+        sf_error("Need clip=");
+
+    // Trace storage
+    var trace: [0..n1-1] real(32);
+
+    // For every trace
+    for i2 in 0..n2-1 {
+        // Read trace
+        sf_floatread(trace, n1, fin);
+
+        for val in trace {
+            if val >  clip then val =  clip;
+            if val < -clip then val = -clip; 
+        }
+
+        // Write trace
+        sf_floatwrite(trace, n1, fout);
+    }   
+
+    // Close files
+    sf_fileclose(fin);
+    sf_fileclose(fout);
+
+    // End Madagascar
+    sf_close();
+} 

--- a/book/m8r/api/paper.tex
+++ b/book/m8r/api/paper.tex
@@ -417,6 +417,84 @@ The Julia script does not require compilation. Simply make sure that
 \texttt{\$RSFROOT/lib} is in \texttt{JULIA\_LOAD\_PATH} and
 \texttt{LD\_LIBRARY\_PATH}.
 
+\section{Chapel interface}
+
+\renewcommand{\rsfclip}{\RSF/api/chapel/test/clip.chpl}
+
+The Chapel clip program is listed bellow:
+
+\lstinputlisting[frame=single]{\rsfclip}
+
+This code follows the C code pattern, so if you understand
+that code you can understand the chapel one.
+
+\lstinputlisting[firstline=2,lastline=2,frame=single]{\rsfclip}
+We start by including the Chapel-Madagascar API with a use clause.
+
+\lstinputlisting[firstline=11,lastline=11,frame=single]{\rsfclip}
+This line inits the connection with Madagascar using the parameters
+used to run the program.
+
+\lstinputlisting[firstline=14,lastline=15,frame=single]{\rsfclip}
+We declare two Madagascar files. One is initialized to the standard
+input ("in") and the other to the standard output ("out").
+
+\lstinputlisting[firstline=18,lastline=19,frame=single]{\rsfclip}
+For this example we check that the input data is real. If not, the
+program halts with an error message. Integer
+and complex data should be transformed to real data before being
+feeded to this program.
+
+\lstinputlisting[firstline=22,lastline=27,frame=single]{\rsfclip}
+Next, we consult the number of samples along the first data axis
+in \texttt{n1}. In the same way, the sum of the number of samples
+of all other axes is stored in \texttt{n2}. We are going to process
+the data in a doubly nested loop of \texttt{n2} chunks of
+\texttt{n1} samples each one.
+
+\lstinputlisting[firstline=30,lastline=32,frame=single]{\rsfclip}
+The desired clip value is obtained from the command line and stored
+in \texttt{clip}. If there was no clip parameter in the command line
+the program halts with an error message. Other way of getting
+command line parameters is to declare \texttt{clip} as Chapel
+config variable, however, the first way is closer to the 
+Madagascar style.
+
+\lstinputlisting[firstline=35,lastline=35,frame=single]{\rsfclip}
+We allocate enough space to process \texttt{n1} samples at once.
+
+\lstinputlisting[firstline=38,lastline=49,frame=single]{\rsfclip}
+The processing loop is a doubly nested loop as mentioned before.
+It reads each trace with \texttt{n1} samples and each sample is
+compared with the clip value. After that, the processed trace is
+written to the output file. 
+
+\lstinputlisting[firstline=52,lastline=53,frame=single]{\rsfclip}
+It is always recommended to close the opened files after using
+them.
+
+\lstinputlisting[firstline=56,lastline=56,frame=single]{\rsfclip}
+Finally, we close the connection to Madagascar.
+
+\subsection{Compiling}
+
+To compile this Chapel code use the following command:
+
+\begin{verbatim}
+chpl --fast -I$RSFROOT/include -L$RSFROOT/lib -M$RSFROOT/lib -lrsf clip.chpl
+\end{verbatim}
+
+\noindent
+You must change \texttt{chpl} to the Chapel compiler in your system. The
+flag \texttt{--fast} is optional but it enables code optimization. There
+are many more Chapel flags that you can consult by invoking the compiler
+without artumrnts. After \texttt{-I} it should be the location of the 
+C file \texttt{rsf.h} that the Chapel API wraps up. The flag \texttt{-lrsf}
+is for linking the Madagascar C library \texttt{librsf} and the path after
+\texttt{-L} indicates the location of this library. The path after
+\texttt{-M} is where the Chapel API file \texttt{m8r.chpl} is located.
+Finally, \texttt{clip.chpl} is the Chapel source file.
+
 \section{Installation} 
 
 To install the interface to a particular language, use \texttt{API=}

--- a/book/rsf/rsf/afdm/SConstruct
+++ b/book/rsf/rsf/afdm/SConstruct
@@ -4,7 +4,7 @@ from rsf.proj import *
 
 prog = {}
 
-for lang in ('c','c++','f90','python','julia'):
+for lang in ('c','c++','f90','python','julia','chapel'):
     if lang != 'julia' or WhereIs('julia'):   
         SConscript('../../../../api/%s/test/SConstruct' % lang)
         prog[lang] = '../../../../api/%s/test/afdm.exe' % lang

--- a/book/rsf/rsf/demo.tex
+++ b/book/rsf/rsf/demo.tex
@@ -390,4 +390,97 @@ $U_{i+1} = \left[ \Delta U -f(t) \right] v^2 \Delta t^2 + 2 U_{i} - U_{i-1}$
 
 \end{comment}
 
+% ------------------------------------------------------------
+\newpage
+\section{Chapel program}
+\lstset{numbers=left,numberstyle=\tiny,showstringspaces=false}
+\renewcommand{\rsfafdm}{\RSF/api/chapel/test/afdm.chpl}
+
+\tiny
+\lstinputlisting[frame=single]{\rsfafdm}
+\normalsize
+\newpage
+
+\begin{enumerate}
+\item Init Madagascar.
+\tiny
+\lstinputlisting[firstline=13,lastline=13,frame=single]{\rsfafdm}
+\normalsize
+
+\item Open files for input/output
+\tiny
+\lstinputlisting[firstline=17,lastline=21,frame=single]{\rsfafdm}
+\normalsize
+
+\item Read input axes information: length and sampling.
+\tiny
+\lstinputlisting[firstline=24,lastline=29,frame=single]{\rsfafdm}
+\normalsize
+
+\item Setup output axes.
+\tiny
+\lstinputlisting[firstline=31,lastline=36,frame=single]{\rsfafdm}
+\normalsize
+
+\item Allocate space and read input datasets: source wavelet, 
+	velocity and reflectivity.
+\tiny
+\lstinputlisting[firstline=43,lastline=45,frame=single]{\rsfafdm}
+\normalsize
+
+\item Allocate wavefield arrays.
+\tiny
+\lstinputlisting[firstline=48,lastline=51,frame=single]{\rsfafdm}
+\normalsize
+
+\item Loop over time.
+\tiny
+\lstinputlisting[firstline=54,lastline=54,frame=single]{\rsfafdm}
+\normalsize
+
+\item Compute Laplacian: $\Delta U$. Uses data parallellism.
+\tiny
+\lstinputlisting[firstline=57,lastline=63,frame=single]{\rsfafdm}
+\normalsize
+
+\item Inject source wavelet: $\left[ \Delta U - f(t) \right]$. 
+	Uses data parallelism.
+\tiny
+\lstinputlisting[firstline=66,lastline=68,frame=single]{\rsfafdm}
+\normalsize
+
+\item Scale by velocity: $\left[ \Delta U - f(t) \right] v^2$. Uses
+	data parallelism.
+\tiny
+\lstinputlisting[firstline=71,lastline=73,frame=single]{\rsfafdm}
+\normalsize
+
+\item Time step:
+$U_{i+1} = \left[ \Delta U -f(t) \right] v^2 \Delta t^2 + 2 U_{i} - U_{i-1}$.
+Uses data parallelism.
+\tiny
+\lstinputlisting[firstline=76,lastline=80,frame=single]{\rsfafdm}
+\normalsize
+
+\item Interchange wavefields.
+\tiny
+\lstinputlisting[firstline=83,lastline=84,frame=single]{\rsfafdm}
+\normalsize
+
+\item Write current wavefield state to output.
+\tiny
+\lstinputlisting[firstline=87,lastline=87,frame=single]{\rsfafdm}
+\normalsize
+
+\item Close input and output files.
+\tiny
+\lstinputlisting[firstline=91,lastline=94,frame=single]{\rsfafdm}
+\normalsize
+
+\item Stops Madagascar.
+\tiny
+\lstinputlisting[firstline=97,lastline=97,frame=single]{\rsfafdm}
+\normalsize	
+
+\end{enumerate}
 

--- a/framework/configure.py
+++ b/framework/configure.py
@@ -158,8 +158,10 @@ def check_all(context):
         matlab(context)
     if 'octave' in api:
         octave(context)
-    if 'java' in api:
+    if 'java' in api:        
         java(context)
+    if 'chapel' in api:
+        chapel(context)
     mpi (context) # FDNSI
     pthreads (context) # FDNSI
     omp (context) # FDNSI
@@ -2014,7 +2016,8 @@ def api_options(context):
     api = [x.lower() for x in path_get(context,'API')]
 
     valid_api_options = ['','c++', 'fortran', 'f77', 'fortran-90',
-                         'f90', 'python', 'matlab', 'octave', 'java']
+                         'f90', 'python', 'matlab', 'octave', 'java',
+                         'chapel']
 
     for option in api:
         if not option in valid_api_options:
@@ -2425,6 +2428,20 @@ def java(context):
         context.Result(context_failure)
         need_pkg('minesjtk', fatal=False)
 
+def chapel(context):
+    context.Message("checking for chapel ... ")
+    CHPL = context.env.get('CHPL_HOST_COMPILER',WhereIs('chpl'))
+    context.env['CHPL_HOST_COMPILER'] = CHPL;
+    #print(CHPL)
+    if not CHPL:
+        context.Result(context_failure)
+        need_pkg('chapel', fatal = False)
+        if 'chapel' in api:
+            api.remove('chapel')
+            context.env['API'] = api
+    else:
+        context.Result(CHPL)
+
 def gcc(context):
     '''Handle dynamic gcc libraries.'''
     libdirs = os.environ.get('LD_LIBRARY_PATH','').split(':')
@@ -2566,6 +2583,8 @@ def options(file):
     opts.Add('JAVAC','The Java compiler')
     opts.Add('JAVA_HOME','Location of jdk')
     opts.Add('MINESJTK','Location of edu_mines_jtk.jar')
+    opts.Add('CHPL_HOST_COMPILER', 'Chapel compiler')
+    opts.Add('CHPLFLAGS','Chapel compiler flags','--fast')
     opts.Add('CUDA_TOOLKIT_PATH','Location of CUDA toolkit')
     opts.Add('NVCC','NVIDIA C compiler')
     opts.Add('CUDAFLAGS','NVCC flags')

--- a/framework/configure.py
+++ b/framework/configure.py
@@ -158,7 +158,7 @@ def check_all(context):
         matlab(context)
     if 'octave' in api:
         octave(context)
-    if 'java' in api:        
+    if 'java' in api:
         java(context)
     if 'chapel' in api:
         chapel(context)

--- a/framework/rsf/doc.py
+++ b/framework/rsf/doc.py
@@ -998,7 +998,7 @@ def getprog(file,out,lang = 'c',rsfprefix = 'sf',rsfsuffix='rsf',
             type = par[1]
             default = par[2]
             desc = par[3]
-            range = ''    
+            range = ''
         else: # c
             type = par[0]
             parname = par[1]

--- a/framework/rsf/doc.py
+++ b/framework/rsf/doc.py
@@ -881,6 +881,19 @@ inpout['c'] = re.compile(r'\s*(?P<name>\w+)\s*=\s*'
 version['c'] = re.compile(r'\/\*\s*\$Id\:\s*(.+\S)\s*\$\s*\*\/')
 chars['c'] = ' '
 
+comment['chpl'] = re.compile(r'\/\/(?P<comment>[^\n]+)\n')
+inpout['chpl'] = re.compile(r'\s*var\s+(?P<name>\w+)\s*\:\s*'
+                             '(?:RSF\.)?sf_file\s*=\s*'
+                             '(?:RSF\.)?sf_(?P<io>input|output)'
+                             '\s*\(\s*\"?(?P<tag>\w+)\"?\s*\)')
+param['chpl'] = re.compile(r'\s*config\s+(?:const|var)\s+(?P<name>\w+)'
+                            '\s*\:\s*(?P<type>bool|int|uint|real|imag|'
+                            'complex|string)'
+                            '(?:\([0-9]+\))?\s*\=\s*\"?'
+                            '(?P<default>[^\;\"]+)\"?\s*\;'
+                            '\s*\/\/(?P<desc>[^\n]+)')
+version['chpl'] = re.compile(r'\/\/\s*\$Id\:\s*(.+\S)\s*\$/')
+
 
 def getprog(file,out,lang = 'c',rsfprefix = 'sf',rsfsuffix='rsf',
             rsfplotprefix='vp',rsfplotsuffix='vpl',known_version='unknown',strip = None):
@@ -897,7 +910,7 @@ def getprog(file,out,lang = 'c',rsfprefix = 'sf',rsfsuffix='rsf',
     elif lang[0] =='f':
         name = re.sub('\.f\d*$','',name)
     else:
-        name = re.sub('\.c(c|u)?$','',name)
+        name = re.sub('\.c(c|u|hpl)?$','',name)
     cname = re.sub('\-','',name)
     src = open(file,"r")   # open source
     text = ''.join(src.readlines())
@@ -980,6 +993,12 @@ def getprog(file,out,lang = 'c',rsfprefix = 'sf',rsfsuffix='rsf',
             default = par[2]
             range = par[3]
             desc = par[4]
+        elif lang == 'chpl':
+            parname = par[0]
+            type = par[1]
+            default = par[2]
+            desc = par[3]
+            range = ''    
         else: # c
             type = par[0]
             parname = par[1]

--- a/user/jsun/lowrank.cc
+++ b/user/jsun/lowrank.cc
@@ -32,7 +32,7 @@ static vector<int> lidx, ridx;
 static ZpxNumMat mid;
 static vector<int> ms, ns, js;
 
-static int (*sample)(vector<int>& rs, vector<int>& cs, ZpxNumMat& res);
+static int (*mysample)(vector<int>& rs, vector<int>& cs, ZpxNumMat& res);
 
 static int sample_iso(vector<int>& rs, vector<int>& cs, ZpxNumMat& res)
 {
@@ -109,7 +109,7 @@ void lowrank_init(int jump,
     // media
     switch(media) {
         case 1:
-            sample = &sample_tti;
+            mysample = &sample_tti;
             kzs.resize(n); kxs.resize(n); kys.resize(n);
             for (int iy=0; iy < dft->nky; iy++) {
                 float ky = dft->oky+iy*dft->dky;
@@ -125,7 +125,7 @@ void lowrank_init(int jump,
             }
             break;
         default:
-            sample = &sample_iso;
+            mysample = &sample_iso;
             ks.resize(n);
             for (int iy=0; iy < dft->nky; iy++) {
                 float ky = dft->oky+iy*dft->dky;
@@ -170,8 +170,8 @@ int lowrank_rank()
 
     srand48(seed);
 
-    //iC( ddlowrank(m,n,sample,(double)eps,npk,lidx,ridx,mid) );
-    iC( ddlowrank(ms,ns,js,sample,(double)eps,npk,lidx,ridx,mid) );
+    //iC( ddlowrank(m,n,mysample,(double)eps,npk,lidx,ridx,mid) );
+    iC( ddlowrank(ms,ns,js,mysample,(double)eps,npk,lidx,ridx,mid) );
 
     nrank = mid.n();
     return nrank;
@@ -190,7 +190,7 @@ void lowrank_mat(sf_complex **lt, sf_complex **rt)
 	nidx[k] = k;    
 
     ZpxNumMat lmat(m,m2);
-    iC ( sample(midx,lidx,lmat) );
+    iC ( mysample(midx,lidx,lmat) );
 
     ZpxNumMat lmat2(m,n2);
     iC( zzgemm(1.0, lmat, mid, 0.0, lmat2) );
@@ -202,7 +202,7 @@ void lowrank_mat(sf_complex **lt, sf_complex **rt)
             lt[i][k] = sf_cmplx(real(ldat[i*m+k]),imag(ldat[i*m+k]));
 
     ZpxNumMat rmat(n2,n);
-    iC ( sample(ridx,nidx,rmat) );
+    iC ( mysample(ridx,nidx,rmat) );
     zpx *rdat = rmat.data();
 
     for (int k=0; k < n; k++)


### PR DESCRIPTION
The Chapel parallel programming language API is provided. Two working examples using this API, clip.chpl and afdm.chpl, are also added. The framework/configure.py and framework/rsf/doc.py  files are modified accordingly. The documentation demos at book/m8r/api/paper.tex and book/rsf/rsf/demo.tex are updated with Chapel examples using the API. 

Not related, a C++ ambiguity error is fixed in user/jsun/lowrank.cc. The standard library already contains a "std::sample" generic function that some compilers can not  distinguish from the pointer "sample" defined in the code. 