### PR TITLE
replace cgi.escape with html.escape,

### DIFF
--- a/framework/rsf/tex.py
+++ b/framework/rsf/tex.py
@@ -16,8 +16,8 @@
 
 from __future__ import print_function, division, absolute_import
 import os, re, glob, string, types, pwd, shutil
-import io, token, tokenize, cgi, sys, keyword
-
+import io, token, tokenize, sys, keyword
+import html as html_module
 import rsf.conf, rsf.path, rsf.latex2wiki
 import rsf.doc
 import rsf.prog
@@ -626,7 +626,7 @@ def colorize(target=None,source=None,env=None):
 
           # send text
           out.write('<span class="%s">' % style)
-          out.write(cgi.escape(toktext))
+          out.write(html_module.escape(toktext))
           out.write('</span>')
 
      try:


### PR DESCRIPTION
 feature no longer supported by cgi for python version > 3.85