### PR TITLE
A small fix in order to successfully compile and install under the new ffmpeg version

### DIFF
--- a/framework/configure.py
+++ b/framework/configure.py
@@ -921,7 +921,7 @@ def ffmpeg(context):
     #if LIBAVCODEC_VERSION_MAJOR < 54
     avcodec_init ();
     #endif
-    avcodec_register_all ();
+    //avcodec_register_all ();
     return 0;
     }\n'''
     ffmpeg = context.env.get('FFMPEG','avcodec avutil')


### PR DESCRIPTION
One small fix, commenting out the av_register_all() function allows ffmpeg to be compiled for rolling distributions.


ffmpeg's av_register_all() function was deprecated 5 years ago. This allows madagascar to compile only with a deprecation warning when compiled on a stable distribution such as Debian. However, on rolling distributions such as Arch, the compilation will fail because av_register_all() is actually removed.