### PR TITLE
Fix a bug (vplot2eps)

### DIFF
--- a/pens/scripts/vplot2eps.py
+++ b/pens/scripts/vplot2eps.py
@@ -36,7 +36,7 @@ def convert(vplot,eps,
     opts = os.environ.get('PSTEXPENOPTS',options)
 
     # Get bounding box info from vplot file
-    getbb = vppen + ' big=y stat=l %s < %s | head -1' % (opts,vplot)
+    getbb = vppen + ' big=y stat=l %s < %s | head -1 | cut -d : -f 2' % (opts,vplot)
 
     out = os.popen(getbb)
     head = out.read().split()
@@ -44,14 +44,14 @@ def convert(vplot,eps,
 
     # Use parameters for bounding box if supplied.
     # Otherwise use bounding box from vplot file.
-    if xbmin==None: xbbm = head[7]
+    if xbmin==None: xbbm = head[6]
     else:           xbbm = xbmin
-    if xbmax==None: xbbp = head[9]
+    if xbmax==None: xbbp = head[8]
     else:           xbbp = xbmax
 
-    if ybmin==None: ybbm = head[12]
+    if ybmin==None: ybbm = head[11]
     else:           ybbm = ybmin
-    if ybmax==None: ybbp = head[14]
+    if ybmax==None: ybbp = head[13]
     else:           ybbp = ybmax
 
     # Compute bounding box


### PR DESCRIPTION
Fix a bug that occurs sometimes on a specific encoding machine (e.g. … zh_CN.UTF-8).
This could happen when one try to convert a vplot file to eps figure. 
```bash
$ vpconvert bin1.vpl bin1.eps                                
Traceback (most recent call last):
  File "/home/jwchen/madagascar/RSFROOT/bin/vpconvert", line 223, in <module>
    convert(infile,outfile,format,pen,args)
  File "/home/jwchen/madagascar/RSFROOT/bin/vpconvert", line 128, in convert
    rsf.vplot2eps.convert(vpl,out,
  File "/home/jwchen/madagascar/RSFROOT/lib/python3.10/site-packages/rsf/vplot2eps.py", line 42, in convert
    head = out.read().split()
  File "/usr/lib/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf1 in position 20: invalid continuation byte
```
which is caused by this command: 
Line 39 in vplot2eps:
```python
    getbb = vppen + ' big=y stat=l %s < %s | head -1' % (opts,vplot)
```
On some machines with zh_CN.UTF-8, the command above will output a message like this:
```bash
/var/tmp/vppenELmctTcU: h=   8.66 w=   8.66 ;  x=(   0.73 ,   9.39 ) y=(   1.28 ,   9.94 ) 
```
The temporary filename cannot be decoded by 'utf-8' codec of os.read().
Using 'cut -d : -f 2' can avoid reading those bytes.