### PR TITLE
CLI CPPPATH/LIBPATH/LINKFLAGS to scons env

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -43,6 +43,27 @@ opts = configure.options('config.py')
 opts.Add('RSFROOT','RSF installation root',root)
 opts.Update(env)
 
+# Apply command-line CPPPATH/LIBPATH/LINKFLAGS to environment
+from SCons.Script import ARGUMENTS
+for var in ('CPPPATH', 'LIBPATH'):
+    val = ARGUMENTS.get(var)
+    if val:
+        env[var] = val.split(',')
+val = ARGUMENTS.get('LINKFLAGS')
+if val:
+    env['LINKFLAGS'] = val
+for var in ('MPICC', 'MPICXX'):
+    val = ARGUMENTS.get(var)
+    if val:
+        env[var] = val
+
+# Pass OpenMPI compiler wrappers through to child processes
+import os as _os
+for evar in ('OMPI_CC', 'OMPI_CXX'):
+    val = _os.environ.get(evar)
+    if val:
+        env['ENV'][evar] = val
+
 if not os.path.isfile('config.py'):
     conf = Configure(env,custom_tests={'CheckAll':configure.check_all})
     conf.CheckAll()


### PR DESCRIPTION
Variables like CPPPATH or LIBPATH passed on the configure command (./configure) prior to scons install are accepted without error but never applied to the build bc they are not registered with opts.Add().

path_get() in configure.py already supports comma-separated strings but never receives them.

Read these variables from ARGUMENTS and apply them to env directly. Also forward OMPI_CC/OMPI_CXX to child processes so Open MPI compiler wrappers use the correct compiler (e.g. LLVM clang with OpenMP support instead of Apple system clang).