### PR TITLE
Fix incompatible sft pointer types  in sf_ntrianglen_init

### DIFF
--- a/user/chenyk/Mdipln.c
+++ b/user/chenyk/Mdipln.c
@@ -26,12 +26,13 @@ int main(int argc, char*argv[])
 	sf_file in, out;
 	int m, n, n1, n2, n3, niter, liter;
 	int i3;
-	bool verb, slope;
+	bool verb, slope, sft_float[SF_MAX_DIM] = {false};
 	float **wav, **dip, radius, eta, dip0;
 	char *interp;
 
 	/*added for non-stationary regularization*/
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */	
 	int i, j, b, n123, dim;
 	float eps;
@@ -100,7 +101,10 @@ int main(int argc, char*argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -115,14 +119,20 @@ int main(int argc, char*argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n123,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n123);
+		    sf_intread(sft_read,n123,shift[i]);
+		    for (j=0; j < n123; j++) sft[i][j] = (float)sft_read[j];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {
@@ -165,6 +175,3 @@ int main(int argc, char*argv[])
 	free(wav);
 	return 0;
 }
-
-
-

--- a/user/chenyk/Mdipn.c
+++ b/user/chenyk/Mdipn.c
@@ -25,7 +25,9 @@ also see sfdip
 
 int main (int argc, char *argv[])
 {
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    bool sft_float[SF_MAX_DIM] = {false};
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int n123, niter, order, nj1,nj2, i, j, liter, dim, b;
     int n[SF_MAX_DIM], n4, nr, ir; 
@@ -94,7 +96,10 @@ int main (int argc, char *argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -109,14 +114,20 @@ int main (int argc, char *argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n123,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n123);
+		    sf_intread(sft_read,n123,shift[i]);
+		    for (j=0; j < n123; j++) sft[i][j] = (float)sft_read[j];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {
@@ -299,4 +310,3 @@ int main (int argc, char *argv[])
 
     exit (0);
 }
-

--- a/user/chenyk/Mdipn_fb.c
+++ b/user/chenyk/Mdipn_fb.c
@@ -25,7 +25,9 @@ also see sfdip
 
 int main (int argc, char *argv[])
 {
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    bool sft_float[SF_MAX_DIM] = {false};
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int n123, niter, order, nj1,nj2, i, j, liter, dim, b;
     int n[SF_MAX_DIM], n4, nr, ir; 
@@ -94,7 +96,10 @@ int main (int argc, char *argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -109,14 +114,20 @@ int main (int argc, char *argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n123,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n123);
+		    sf_intread(sft_read,n123,shift[i]);
+		    for (j=0; j < n123; j++) sft[i][j] = (float)sft_read[j];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {
@@ -299,4 +310,3 @@ int main (int argc, char *argv[])
 
     exit (0);
 }
-

--- a/user/chenyk/Mltftn.c
+++ b/user/chenyk/Mltftn.c
@@ -24,7 +24,7 @@
 
 int main(int argc, char* argv[])
 {
-    bool inv, verb;
+    bool inv, verb, sft_float[SF_MAX_DIM] = {false};
     int i1, n1, iw, nt, nw, i2, n2, rect0, rectf, niter, n12, n1w;
     int m[SF_MAX_DIM], *rect;
     float t, d1, w, w0, dw, mean=0.0f, alpha;
@@ -122,7 +122,8 @@ int main(int argc, char* argv[])
     
 	/*box means maximum (edge) padding for triangle smoothing, box[i]=max(rect[i])*/
 	sf_file rects[SF_MAX_DIM], shift[SF_MAX_DIM]; 
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
 
 
@@ -148,7 +149,10 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -191,13 +195,19 @@ int main(int argc, char* argv[])
 	  }
 		box[ii] = 1;
 	  	rct[ii] = sf_floatalloc (n21*nw*2);
-	    sft[ii] = sf_intalloc (n21*nw*2);
+	    sft[ii] = sf_floatalloc (n21*nw*2);
 
 	    sf_floatread(rct[ii],n21*nw*2,rects[i]);
 	    sf_fileclose(rects[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[ii],n21*nw*2,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[ii],n21*nw*2,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n21*nw*2);
+		    sf_intread(sft_read,n21*nw*2,shift[i]);
+		    for (i1=0; i1 < n21*nw*2; i1++) sft[ii][i1] = (float)sft_read[i1];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n21*nw*2; i1++) {

--- a/user/chenyk/Morthoa.c
+++ b/user/chenyk/Morthoa.c
@@ -23,8 +23,9 @@
 
 int main(int argc, char* argv[])
 {
-    bool verb, ifsm, ifnm, ifns;
-    int *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    bool verb, ifsm, ifnm, ifns, sft_float[SF_MAX_DIM] = {false};
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     int i, id, dim, n[SF_MAX_DIM], dim1, nd, i1, i2, i3, n1, n2,n3, b, nrad;
     float *noi, *sig, *rat, *rat1, *noi2, *sig2, remove, alpha, beta, gamma;
     char key[8];
@@ -69,7 +70,10 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -105,13 +109,19 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n1,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n1);
+		    sf_intread(sft_read,n1,shift[i]);
+		    for (i1=0; i1 < n1; i1++) sft[i][i1] = (float)sft_read[i1];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {

--- a/user/chenyk/Morthon.c
+++ b/user/chenyk/Morthon.c
@@ -22,8 +22,9 @@
 
 int main(int argc, char* argv[])
 {
-    bool verb;
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    bool verb, sft_float[SF_MAX_DIM] = {false};
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int i, id, dim, n[SF_MAX_DIM], dim1, nd, niter, n1, n2, i1, b;
     float *noi, *sig, *rat, *noi2, *sig2, eps, remove;
@@ -62,7 +63,10 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -94,13 +98,19 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n1,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n1);
+		    sf_intread(sft_read,n1,shift[i]);
+		    for (i1=0; i1 < n1; i1++) sft[i][i1] = (float)sft_read[i1];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {

--- a/user/chenyk/Msmoothn.c
+++ b/user/chenyk/Msmoothn.c
@@ -25,7 +25,8 @@ Example: chenyk/ortho_non/nsmooth
 
 int main (int argc, char* argv[]) 
 {
-    int *sft[SF_MAX_DIM];
+    bool sft_float[SF_MAX_DIM] = {false}; int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];
     int box[SF_MAX_DIM], n[SF_MAX_DIM];
     int dim, dim1, i, n1, n2, i1, i2, b, nrep;
     float *data, *smoo, *rct[SF_MAX_DIM];
@@ -56,7 +57,10 @@ int main (int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(shift[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -82,13 +86,19 @@ int main (int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n1,shift[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n1);
+		    sf_intread(sft_read,n1,shift[i]);
+		    for (i1=0; i1 < n1; i1++) sft[i][i1] = (float)sft_read[i1];
+		}
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {
@@ -120,5 +130,3 @@ int main (int argc, char* argv[])
 
     exit (0);
 }
-
-

--- a/user/chenyk/Mwarpscann.c
+++ b/user/chenyk/Mwarpscann.c
@@ -29,8 +29,9 @@
 
 int main(int argc, char* argv[])
 { 
-    bool shift, verb;
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    bool shift, verb, sft_float[SF_MAX_DIM] = {false};
+    int *sft_read=NULL;
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int box[SF_MAX_DIM];
     int i, i1, mode, b, n1, m[4], ntr, n2, order, ng, rect[4], niter, n2g, dim;
@@ -151,7 +152,10 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		SFT[i] = sf_input(key);
-		if (SF_INT != sf_gettype(SFT[i])) sf_error("Need int %s",key);
+		if (SF_INT != sf_gettype(SFT[i])) {
+		    sft_float[i] = true;
+		    if (SF_FLOAT != sf_gettype(SFT[i])) sf_error("Need int or float %s",key);
+		}
 	    } else {
 		SFT[i] = NULL;
 	    }
@@ -166,11 +170,17 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != RCT[i]) {
 	    rct[i] = sf_floatalloc (n2g);
-	    sft[i] = sf_intalloc (n2g);
+	    sft[i] = sf_floatalloc (n2g);
 	    sf_floatread(rct[i],n2g,RCT[i]);
 	    sf_fileclose(RCT[i]);
 	    if (NULL != SFT[i]) {
-		sf_intread(sft[i],n2g,SFT[i]);
+		if (sft_float[i]) {
+		    sf_floatread(sft[i],n2g,SFT[i]);
+		} else {
+		    if (NULL == sft_read) sft_read = sf_intalloc(n2g);
+		    sf_intread(sft_read,n2g,SFT[i]);
+		    for (i1=0; i1 < n2g; i1++) sft[i][i1] = (float)sft_read[i1];
+		}
 		sf_fileclose(SFT[i]);
 	    } else {
 		for (i1=0; i1 < n2g; i1++) {
@@ -215,4 +225,3 @@ int main(int argc, char* argv[])
 
     exit (0);
 }
-

--- a/user/chenyk/dipln.c
+++ b/user/chenyk/dipln.c
@@ -48,12 +48,12 @@ static int nn[3];
 
 /*for non-stationary regularization*/
 void odipn_init(char* interp, int mf1, int mf2, float rad,
-	       int m1, int m2, int *nbox, float **rct, int **sft , int niter, float dip0, float eps1, bool vb)
+	       int m1, int m2, int *nbox, float **rct, float **sft , int niter, float dip0, float eps1, bool vb)
 /*< initialize >*/
 {
 /* int *nbox: triangle radius [ndim] */
 /* float **rct: triangle lengths [ndim][nd] */
-/* int **sft: triangle shifts [ndim][nd] */	 
+/* float **sft: triangle shifts [ndim][nd] */	 
 
     int n;
     nf1 = mf1;

--- a/user/chenyk/diputil.c
+++ b/user/chenyk/diputil.c
@@ -775,7 +775,7 @@ void dip3_init(int m1, int m2, int m3 /* dimensions */,
 void dip3n_init(int m1, int m2, int m3 /* dimensions */, 
 		   int *nbox 			  /* triangle radius [ndim] */, 
 		   float **rct 			  /* triangle lengths [ndim][nd] */,
-           int **sft 			  /* triangle shifts [ndim][nd] */,	       
+           float **sft 			  /* triangle shifts [ndim][nd] */,	       
 	       int niter              /* number of iterations */,
 	       float eps1             /* regularization */,      
 	       bool verb              /* verbosity flag */)

--- a/user/chenyk/divnn.c
+++ b/user/chenyk/divnn.c
@@ -28,7 +28,7 @@ void divnn_init(int ndim   /* number of dimensions */,
 		  int *nbox /* triangle radius [ndim] */, 
 		  int *ndat  /* data dimensions [ndim] */, 
 		  float **rct /* triangle lengths [ndim][nd] */,
-          int **sft /* triangle shifts [ndim][nd] */,
+          float **sft /* triangle shifts [ndim][nd] */,
 		  int niter1 /* number of iterations */,
 		  bool verb  /* verbosity */) 
 /*< initialize >*/

--- a/user/chenyk/divnn_sc.c
+++ b/user/chenyk/divnn_sc.c
@@ -194,7 +194,7 @@ void divnn_sc_init2(int nw       /* number of components */, \
 		     int *ndat    /* data dimensions [ndim] */, 
 		     int *nbox    /* smoothing radius [nw] */,
 		  	 float **rct /* triangle lengths [ndim][nd] */,
-          	 int **sft /* triangle shifts [ndim][nd] */,
+          	 float **sft /* triangle shifts [ndim][nd] */,
 		     float* den   /* denominator [nw*nd] */,
 		     bool verb    /* verbosity flag */)
 /*< initialize >*/

--- a/user/chenyk/warpscann.c
+++ b/user/chenyk/warpscann.c
@@ -149,7 +149,7 @@ void warpscann_init(int m1     /* input trace length */,
 		   int *m     /* data dimensions [dim] */, 
 		   int *box   /* triangle radius [ndim], maximum smoothing radius */, 
 		   float **rct /* triangle lengths [ndim][nd] */,
-		   int **sft  /* triangle shifts [ndim][nd] */,
+		   float **sft  /* triangle shifts [ndim][nd] */,
 		   int niter  /* number of iterations */,
 		   bool shift1 /* shift instead of strech */,
 		   bool verb  /* verbosity */)


### PR DESCRIPTION
# Problem

```sf_ntrianglen_init()``` expects the shift argument to be ```float **sft```, but several real-valued programs and intermediate functions under ```user/chenyk``` still declared and passed it as ```int **sft```.

This caused build failures such as:
```
error: passing argument 5 of 'sf_ntrianglen_init' from incompatible pointer type
note: expected 'float **' but argument is of type 'int **'
```
Since GCC 14, incompatible pointer types are treated as errors by default. Although the diagnostic can be downgraded using `-Wno-error=incompatible-pointer-types`, doing so does not make the code valid: passing `int **` where `float **` is expected causes the underlying integer data to be accessed as floating-point data, resulting in undefined behavior.



# Changes
- Change ```sft``` from ```int **``` to ```float **``` throughout the affected real-valued call chains
- Update the corresponding ```M*.c``` programs to allocate floating-point shift arrays
- Preserve compatibility with existing integer ```shift#``` inputs by reading them into a temporary integer buffer and converting them to float
- Allow floating-point ```shift#``` inputs to be read directly
- Keep the complex-valued ```cntrianglen``` call chain unchanged

# Affected call chains
- ```sf_ntrianglen_init```
- ```divnn_init```
- ```divnn_sc_init2```
- ```dip3n_init```
- ```odipn_init```
- ```warpscann_init```

The primary purpose of this change is to fix the incompatible pointer types in the real-valued non-stationary smoothing implementation.