### PR TITLE
Fix type mismatches in user/chenyk for GCC/Fedora build

### DIFF
--- a/user/chenyk/Mdipln.c
+++ b/user/chenyk/Mdipln.c
@@ -31,7 +31,7 @@ int main(int argc, char*argv[])
 	char *interp;
 
 	/*added for non-stationary regularization*/
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */	
 	int i, j, b, n123, dim;
 	float eps;
@@ -100,7 +100,7 @@ int main(int argc, char*argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -115,14 +115,14 @@ int main(int argc, char*argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		sf_floatread(sft[i],n123,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {

--- a/user/chenyk/Mdipn.c
+++ b/user/chenyk/Mdipn.c
@@ -25,7 +25,7 @@ also see sfdip
 
 int main (int argc, char *argv[])
 {
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int n123, niter, order, nj1,nj2, i, j, liter, dim, b;
     int n[SF_MAX_DIM], n4, nr, ir; 
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -109,14 +109,14 @@ int main (int argc, char *argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		sf_floatread(sft[i],n123,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {

--- a/user/chenyk/Mdipn_fb.c
+++ b/user/chenyk/Mdipn_fb.c
@@ -25,7 +25,7 @@ also see sfdip
 
 int main (int argc, char *argv[])
 {
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int n123, niter, order, nj1,nj2, i, j, liter, dim, b;
     int n[SF_MAX_DIM], n4, nr, ir; 
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -109,14 +109,14 @@ int main (int argc, char *argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n123);
-	    sft[i] = sf_intalloc (n123);
+	    sft[i] = sf_floatalloc (n123);
 		/* non-stationary dip smoothness on 1st/2nd/3rd axis */
 
 	    sf_floatread(rct[i],n123,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n123,shift[i]);
+		sf_floatread(sft[i],n123,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (j=0; j < n123; j++) {

--- a/user/chenyk/Mfxynpre2.c
+++ b/user/chenyk/Mfxynpre2.c
@@ -218,6 +218,7 @@ int main (int argc, char *argv[])
 	    		mcp3d1d1dint(sftw[0],sft[0],0,0,0,s1,s2,s3,n1win,n2win,n3win,n1pad,n2pad,n3pad);
 	    		mcp3d1d1dint(sftw[1],sft[1],0,0,0,s1,s2,s3,n1win,n2win,n3win,n1pad,n2pad,n3pad);
 	    		mcp3d1d1dint(sftw[2],sft[2],0,0,0,s1,s2,s3,n1win,n2win,n3win,n1pad,n2pad,n3pad);
+
     			fxynpre3(dtmp[0],n2win*n3win,n2win,n3win,n1win,d1,o11,niter,nsx,nsy,box,rctw,sftw,sym,opt,verb);	 
 	    		}
 	    		else

--- a/user/chenyk/Mltftn.c
+++ b/user/chenyk/Mltftn.c
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
     
 	/*box means maximum (edge) padding for triangle smoothing, box[i]=max(rect[i])*/
 	sf_file rects[SF_MAX_DIM], shift[SF_MAX_DIM]; 
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
 
 
@@ -148,7 +148,7 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -191,13 +191,13 @@ int main(int argc, char* argv[])
 	  }
 		box[ii] = 1;
 	  	rct[ii] = sf_floatalloc (n21*nw*2);
-	    sft[ii] = sf_intalloc (n21*nw*2);
+	    sft[ii] = sf_floatalloc (n21*nw*2);
 
 	    sf_floatread(rct[ii],n21*nw*2,rects[i]);
 	    sf_fileclose(rects[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[ii],n21*nw*2,shift[i]);
+		sf_floatread(sft[ii],n21*nw*2,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n21*nw*2; i1++) {

--- a/user/chenyk/Morthoa.c
+++ b/user/chenyk/Morthoa.c
@@ -24,7 +24,7 @@
 int main(int argc, char* argv[])
 {
     bool verb, ifsm, ifnm, ifns;
-    int *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     int i, id, dim, n[SF_MAX_DIM], dim1, nd, i1, i2, i3, n1, n2,n3, b, nrad;
     float *noi, *sig, *rat, *rat1, *noi2, *sig2, remove, alpha, beta, gamma;
     char key[8];
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -105,13 +105,13 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		sf_floatread(sft[i],n1,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {
@@ -303,9 +303,9 @@ int main(int argc, char* argv[])
 			dtmp[iiw3][iiw2][iiw1]=dtmp[iiw3][iiw2][iiw1]/mmax_r/mmax_s*mmax_n;
 			}
 			
-    		win_weight3d(dtmp,iw1,iw2,iw3,nw1,nw2,nw3,n1win,n2win,n3win,ov1,ov2,ov3);
-    		mcp_ad1d3d(dout,dtmp,s1,s2,s3,0,0,0,n1pad,n2pad,n3pad,n1win,n2win,n3win);
-			}
+	    win_weight3d(dtmp,iw1,iw2,iw3,nw1,nw2,nw3,n1win,n2win,n3win,ov1,ov2,ov3);
+	    mcp_ad1d3d(dout,dtmp,s1,s2,s3,0,0,0,n1pad,n2pad,n3pad,n1win,n2win,n3win);
+	}
     	
     		
     for(i3=0;i3<n3;i3++)

--- a/user/chenyk/Morthon.c
+++ b/user/chenyk/Morthon.c
@@ -23,7 +23,7 @@
 int main(int argc, char* argv[])
 {
     bool verb;
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int i, id, dim, n[SF_MAX_DIM], dim1, nd, niter, n1, n2, i1, b;
     float *noi, *sig, *rat, *noi2, *sig2, eps, remove;
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -94,13 +94,13 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		sf_floatread(sft[i],n1,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {

--- a/user/chenyk/Msmoothn.c
+++ b/user/chenyk/Msmoothn.c
@@ -25,7 +25,7 @@ Example: chenyk/ortho_non/nsmooth
 
 int main (int argc, char* argv[]) 
 {
-    int *sft[SF_MAX_DIM];
+    float *sft[SF_MAX_DIM];
     int box[SF_MAX_DIM], n[SF_MAX_DIM];
     int dim, dim1, i, n1, n2, i1, i2, b, nrep;
     float *data, *smoo, *rct[SF_MAX_DIM];
@@ -56,7 +56,7 @@ int main (int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		shift[i] = sf_input(key);
-		if (SF_INT != sf_gettype(shift[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s",key);
 	    } else {
 		shift[i] = NULL;
 	    }
@@ -82,13 +82,13 @@ int main (int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != rect[i]) {
 	    rct[i] = sf_floatalloc (n1);
-	    sft[i] = sf_intalloc (n1);
+	    sft[i] = sf_floatalloc (n1);
 
 	    sf_floatread(rct[i],n1,rect[i]);
 	    sf_fileclose(rect[i]);
 
 	    if (NULL != shift[i]) {
-		sf_intread(sft[i],n1,shift[i]);
+		sf_floatread(sft[i],n1,shift[i]);
 		sf_fileclose(shift[i]);
 	    } else {
 		for (i1=0; i1 < n1; i1++) {

--- a/user/chenyk/Mwarpscann.c
+++ b/user/chenyk/Mwarpscann.c
@@ -30,7 +30,7 @@
 int main(int argc, char* argv[])
 { 
     bool shift, verb;
-    int   *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
+    float *sft[SF_MAX_DIM];	/* storing non-stationary shifting size */
     float *rct[SF_MAX_DIM]; /* storing non-stationary smoothing radii */
     int box[SF_MAX_DIM];
     int i, i1, mode, b, n1, m[4], ntr, n2, order, ng, rect[4], niter, n2g, dim;
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
 	    if (NULL != sf_getstring(key)) {
 		/*( shift# shifting of the smoothing stencil in #-th dimension /auxiliary input file/ )*/
 		SFT[i] = sf_input(key);
-		if (SF_INT != sf_gettype(SFT[i])) sf_error("Need int %s",key);
+		if (SF_FLOAT != sf_gettype(SFT[i])) sf_error("Need float %s",key);
 	    } else {
 		SFT[i] = NULL;
 	    }
@@ -166,11 +166,11 @@ int main(int argc, char* argv[])
 	box[i] = 1;
 	if (NULL != RCT[i]) {
 	    rct[i] = sf_floatalloc (n2g);
-	    sft[i] = sf_intalloc (n2g);
+	    sft[i] = sf_floatalloc (n2g);
 	    sf_floatread(rct[i],n2g,RCT[i]);
 	    sf_fileclose(RCT[i]);
 	    if (NULL != SFT[i]) {
-		sf_intread(sft[i],n2g,SFT[i]);
+		sf_floatread(sft[i],n2g,SFT[i]);
 		sf_fileclose(SFT[i]);
 	    } else {
 		for (i1=0; i1 < n2g; i1++) {

--- a/user/chenyk/dipln.c
+++ b/user/chenyk/dipln.c
@@ -48,12 +48,12 @@ static int nn[3];
 
 /*for non-stationary regularization*/
 void odipn_init(char* interp, int mf1, int mf2, float rad,
-	       int m1, int m2, int *nbox, float **rct, int **sft , int niter, float dip0, float eps1, bool vb)
+	       int m1, int m2, int *nbox, float **rct, float **sft , int niter, float dip0, float eps1, bool vb)
 /*< initialize >*/
 {
 /* int *nbox: triangle radius [ndim] */
 /* float **rct: triangle lengths [ndim][nd] */
-/* int **sft: triangle shifts [ndim][nd] */	 
+/* float **sft: triangle shifts [ndim][nd] */	 
 
     int n;
     nf1 = mf1;

--- a/user/chenyk/diputil.c
+++ b/user/chenyk/diputil.c
@@ -775,7 +775,7 @@ void dip3_init(int m1, int m2, int m3 /* dimensions */,
 void dip3n_init(int m1, int m2, int m3 /* dimensions */, 
 		   int *nbox 			  /* triangle radius [ndim] */, 
 		   float **rct 			  /* triangle lengths [ndim][nd] */,
-           int **sft 			  /* triangle shifts [ndim][nd] */,	       
+           float **sft 			  /* triangle shifts [ndim][nd] */,	       
 	       int niter              /* number of iterations */,
 	       float eps1             /* regularization */,      
 	       bool verb              /* verbosity flag */)

--- a/user/chenyk/divnn.c
+++ b/user/chenyk/divnn.c
@@ -28,7 +28,7 @@ void divnn_init(int ndim   /* number of dimensions */,
 		  int *nbox /* triangle radius [ndim] */, 
 		  int *ndat  /* data dimensions [ndim] */, 
 		  float **rct /* triangle lengths [ndim][nd] */,
-          int **sft /* triangle shifts [ndim][nd] */,
+          float **sft /* triangle shifts [ndim][nd] */,
 		  int niter1 /* number of iterations */,
 		  bool verb  /* verbosity */) 
 /*< initialize >*/

--- a/user/chenyk/divnn_sc.c
+++ b/user/chenyk/divnn_sc.c
@@ -194,7 +194,7 @@ void divnn_sc_init2(int nw       /* number of components */, \
 		     int *ndat    /* data dimensions [ndim] */, 
 		     int *nbox    /* smoothing radius [nw] */,
 		  	 float **rct /* triangle lengths [ndim][nd] */,
-          	 int **sft /* triangle shifts [ndim][nd] */,
+          	 float **sft /* triangle shifts [ndim][nd] */,
 		     float* den   /* denominator [nw*nd] */,
 		     bool verb    /* verbosity flag */)
 /*< initialize >*/

--- a/user/chenyk/warpscann.c
+++ b/user/chenyk/warpscann.c
@@ -149,7 +149,7 @@ void warpscann_init(int m1     /* input trace length */,
 		   int *m     /* data dimensions [dim] */, 
 		   int *box   /* triangle radius [ndim], maximum smoothing radius */, 
 		   float **rct /* triangle lengths [ndim][nd] */,
-		   int **sft  /* triangle shifts [ndim][nd] */,
+		   float **sft  /* triangle shifts [ndim][nd] */,
 		   int niter  /* number of iterations */,
 		   bool shift1 /* shift instead of strech */,
 		   bool verb  /* verbosity */)


### PR DESCRIPTION
    ## Description                                                                                         
                                                                                                           
    This PR resolves compilation failures and pointer type mismatches in `user/chenyk` encountered when    
  building Madagascar on Linux distributions with modern GCC versions (e.g., Fedora / GCC 14+), which treat
  incompatible pointer types as errors by default.                                                         
                                                                                                           
    ### Context & Problem                                                                                  
    In `user/chenyk`, the non-stationary shift array `sft` was previously declared as `int                 
  *sft[SF_MAX_DIM]` and passed as `int**` into functions like `sf_ntrianglen_init()`, `divnn_init()`, and  
  `odipn_init()`.                                                                                          
                                                                                                           
    However, Madagascar's underlying non-stationary triangle smoothing library (`api/c/ntrianglen.c` and   
  `api/c/ntriangle.c`) defines `sft` as `float**` to support continuous sub-sample shift interpolation     
  (using 3-point Lagrange weights in `triple()`).                                                          
                                                                                                           
    Passing `int**` caused:                                                                                
    1. Strict compiler errors on modern GCC due to incompatible pointer types.                             
    2. Runtime numerical corruption when shifts were supplied, because 32-bit integer values were read as  
  IEEE 754 floats.                                                                                         
                                                                                                           
    ---                                                                                                    
                                                                                                           
    ### Summary of Changes                                                                                 
                                                                                                           
    1. **Aligned `sft` type to `float`:**                                                                  
       - Changed `sft` declaration to `float *sft[SF_MAX_DIM]` in all affected `user/chenyk` main programs.
       - Updated memory allocation from `sf_intalloc()` to `sf_floatalloc()`.                              
       - Updated file reads from `sf_intread()` to `sf_floatread()`.                                       
                                                                                                           
    2. **Updated library function signatures:**                                                            
       - Updated parameter types from `int **sft` to `float **sft` in `dipln.c`, `diputil.c`, `divnn.c`,   
  `divnn_sc.c`, and `warpscann.c`.                                                                         
                                                                                                           
    3. **Fixed input header validation:**                                                                  
       - Updated auxiliary input validation checks from `if (SF_INT != sf_gettype(shift[i]))` to `if       
  (SF_FLOAT != sf_gettype(shift[i])) sf_error("Need float %s", key);` across:
         - `Mdipln.c`
         - `Mdipn.c`
         - `Mdipn_fb.c`
         - `Mltftn.c`
         - `Morthoa.c`
         - `Morthon.c`
         - `Msmoothn.c`
         - `Mwarpscann.c`
       - This matches the reference implementation in `user/fomels/Mnsmooth.c`.
  
    ---
  
    ### Verification & Testing
  
    - [x] **Compilation**: Built all targets in `user/chenyk` with `scons` using GCC; compiled and linked  
  cleanly without warnings or errors.
    - [x] **Static Analysis**: Verified with Clang-Tidy across all 13 modified C source files; 0 errors and
  0 warnings on modified logic